### PR TITLE
changes to send cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When a Notebook is open, the Notebook or a selected cell output may be sent to S
 ![Sending Content to SAGE2](doc/img/2017-11-08_DropDownMenu.png "Sending Content to SAGE2")
 
 Notebooks are sent to SAGE2 and rendered using [nbviewer](http://nbviewer.jupyter.org/). Notebook cells are rendered as images and automatically updated when a cell is re-run.
+This requires that the SAGE2 server has an externally accessible IP or hostname which nbviewer can access. 
 
 <!-- ### How-to
 
@@ -52,13 +53,13 @@ For a development install (requires `npm` version 4 or later), do the following 
 
 ```bash
 npm install
-jupyter labextension link .
+npm run build
+jupyter labextension install .
 ```
 
 To rebuild the package and the JupyterLab app:
 
 ```bash
-npm run build
 jupyter lab build
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,8 +230,8 @@ export
       selectedCell = (shell.currentWidget as NotebookPanel).notebook.activeCell as any;
       let outputs = selectedCell.model.outputs
 
-      if (outputs && outputs.get(0)) {
-        let outputData = outputs.get(0).data;
+      if (outputs && outputs.get(1)) {
+        let outputData = outputs.get(1).data;
 
         for (let mime of supportedCellOutputs) {
           if (outputData[mime]) {
@@ -385,7 +385,7 @@ export
           let codeCell = (notebook.activeCell) as any;
           let cellModel = codeCell.model;
           let outputArea = cellModel.outputs;
-          let outputData = outputArea.get(0).data;
+          let outputData = outputArea.get(1).data;
 
           let dataToSend = null;
 
@@ -403,7 +403,7 @@ export
                 
                 // update on cell change
                 outputArea.changed.connect(function (outputAreaModel: any) {
-                  let newOutput = outputAreaModel.get(0);
+                  let newOutput = outputAreaModel.get(1);
   
                   // send changed output to SAGE2
                   if (newOutput && newOutput.data[mime]) {
@@ -492,7 +492,7 @@ export
       let codeCell = (notebook.activeCell) as any;
       let cellModel = codeCell.model;
       let outputArea = cellModel.outputs;
-      let outputData = outputArea.get(0).data;
+      let outputData = outputArea.get(1).data;
 
       let dataToSend = null;
 
@@ -509,7 +509,7 @@ export
 
             // update on cell change
             outputArea.changed.connect(function (outputAreaModel: any) {
-              let newOutput = outputAreaModel.get(0);
+              let newOutput = outputAreaModel.get(1);
 
               // send updated data to SAGE2
               if (newOutput && newOutput.data[mime]) {


### PR DESCRIPTION
I made some changes to the README to clarify that SAGE2 needs an externally accesible IP, and a small change to the development install. I changed outputs.get(0) to outputs.get(1) since the image is usually stored in (1). This leaves a bug when the cell you're sending has a warning, in which case the image is in outputs.get(2), with the name of the cell and the warning being stored before the image. A fix would be to read all the values and send the one that starts with mime 'image/'.

I'm doing the pull request on dev branch since I haven't been able to get master to work. 